### PR TITLE
Resolve Type Error

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -1,6 +1,6 @@
 interface Runnable<A> {
   fn: () => Promise<A>;
-  resolve: (value?: A | PromiseLike<A> | undefined) => void;
+  resolve: (value: A | PromiseLike<A>) => void;
   reject: (reason?: any) => void;
 }
 


### PR DESCRIPTION
When trying to use this I was receiving this error:
```
error: TS2322 [ERROR]: Type '(value: A | PromiseLike<A>) => void' is not assignable to type '(value: A | PromiseLike<A> | undefined) => void'.
  Types of parameters 'value' and 'value' are incompatible.
    Type 'A | PromiseLike<A> | undefined' is not assignable to type 'A | PromiseLike<A>'.
      Type 'undefined' is not assignable to type 'A | PromiseLike<A>'.
      enqueue({ fn, resolve, reject })
                    ~~~~~~~
    at file:///home/user/Downloads/run_with_limit-master/mod.ts:50:21

    The expected type comes from property 'resolve' which is declared here on type 'Runnable<A>'
      resolve: (value: A | PromiseLike<A> | undefined) => void;
      ~~~~~~~
        at file:///home/user/Downloads/run_with_limit-master/mod.ts:3:3
```
Running the tests also yielded the same error so I adjusted the type on `Runnable` interface and now the tests are passing. Please take a look and see if there is anything concerning with this change to you.